### PR TITLE
Add CytoDataFrame segmentation mask outline capabilities for image display in notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ cython_debug/
 
 # test data ignores
 *.tif
+*.tiff
 *.sqlite
 *.parquet
 *.zip

--- a/docs/examples/cosmicqc_in_a_nutshell.py
+++ b/docs/examples/cosmicqc_in_a_nutshell.py
@@ -30,9 +30,14 @@ data_path = (
 
 # set a context directory for images associated with the dataset
 image_context_dir = pathlib.Path(data_path).parent / "Plate_2_images"
+mask_context_dir = pathlib.Path(data_path).parent / "Plate_2_masks"
 
 # create a cosmicqc CytoDataFrame (single-cell DataFrame)
-scdf = cosmicqc.CytoDataFrame(data=data_path, data_context_dir=image_context_dir)
+scdf = cosmicqc.CytoDataFrame(
+    data=data_path,
+    data_context_dir=image_context_dir,
+    data_mask_context_dir=mask_context_dir,
+)
 
 # display the dataframe
 scdf

--- a/src/cosmicqc/analyze.py
+++ b/src/cosmicqc/analyze.py
@@ -125,6 +125,7 @@ def identify_outliers(
                 axis=1,
             ),
             data_context_dir=df._custom_attrs["data_context_dir"],
+            data_mask_context_dir=df._custom_attrs["data_mask_context_dir"],
         )
     )
 
@@ -289,6 +290,7 @@ def label_outliers(  # noqa: PLR0913
                 axis=1,
             ),
             data_context_dir=df._custom_attrs["data_context_dir"],
+            data_mask_context_dir=df._custom_attrs["data_mask_context_dir"],
         )
 
     # for multiple outlier processing
@@ -315,6 +317,7 @@ def label_outliers(  # noqa: PLR0913
         result = CytoDataFrame(
             labeled_df.loc[:, ~labeled_df.columns.duplicated()],
             data_context_dir=df._custom_attrs["data_context_dir"],
+            data_mask_context_dir=df._custom_attrs["data_mask_context_dir"],
         )
 
     # export the file if specified

--- a/src/cosmicqc/frame.py
+++ b/src/cosmicqc/frame.py
@@ -20,6 +20,7 @@ from typing import (
     Union,
 )
 
+import numpy as np
 import pandas as pd
 import plotly
 import plotly.colors as pc
@@ -34,7 +35,6 @@ from pandas._config import (
 from pandas.io.formats import (
     format as fmt,
 )
-import numpy as np
 from PIL import Image, ImageDraw
 
 # provide backwards compatibility for Self type in earlier Python versions.
@@ -62,7 +62,7 @@ class CytoDataFrame(pd.DataFrame):
 
     _metadata: ClassVar = ["_custom_attrs"]
 
-    def __init__(
+    def __init__(  # noqa: C901, PLR0912, PLR0913
         self: CytoDataFrame_type,
         data: Union[CytoDataFrame_type, pd.DataFrame, str, pathlib.Path],
         data_context_dir: Optional[str] = None,
@@ -150,9 +150,7 @@ class CytoDataFrame(pd.DataFrame):
         else:
             self._custom_attrs["data_bounding_box"] = data_bounding_box
 
-    def __getitem__(
-        self: CytoDataFrame_type, key: Union[int, str]
-    ) -> Any:  # noqa: ANN401
+    def __getitem__(self: CytoDataFrame_type, key: Union[int, str]) -> Any:  # noqa: ANN401
         """
         Returns an element or a slice of the underlying pandas DataFrame.
 
@@ -176,7 +174,9 @@ class CytoDataFrame(pd.DataFrame):
                 data_context_dir=self._custom_attrs["data_context_dir"],
                 data_bounding_box=self._custom_attrs["data_bounding_box"],
                 data_mask_context_dir=self._custom_attrs["data_mask_context_dir"],
-                data_mask_filename_suffix=self._custom_attrs["data_mask_filename_suffix"],
+                data_mask_filename_suffix=self._custom_attrs[
+                    "data_mask_filename_suffix"
+                ],
             )
 
     def _wrap_method(
@@ -211,7 +211,9 @@ class CytoDataFrame(pd.DataFrame):
                 data_context_dir=self._custom_attrs["data_context_dir"],
                 data_bounding_box=self._custom_attrs["data_bounding_box"],
                 data_mask_context_dir=self._custom_attrs["data_mask_context_dir"],
-                data_mask_filename_suffix=self._custom_attrs["data_mask_filename_suffix"],
+                data_mask_filename_suffix=self._custom_attrs[
+                    "data_mask_filename_suffix"
+                ],
             )
         return result
 

--- a/src/cosmicqc/frame.py
+++ b/src/cosmicqc/frame.py
@@ -625,7 +625,7 @@ class CytoDataFrame(pd.DataFrame):
             FileNotFoundError: If the specified image or mask file does not exist.
             ValueError: If the images are not in compatible formats or sizes.
         """
-        # Load the TIFF image and convert it to grayscale array
+        # Load the TIFF image
         tiff_image_array = skimage.io.imread(actual_image_path)
         # Convert to PIL Image and then to 'RGBA'
         tiff_image = Image.fromarray(np.uint8(tiff_image_array)).convert("RGBA")

--- a/tests/data/cytotable/NF1_cellpainting_data/NF1_plate2_export_masks.cppipe
+++ b/tests/data/cytotable/NF1_cellpainting_data/NF1_plate2_export_masks.cppipe
@@ -1,0 +1,227 @@
+CellProfiler Pipeline: http://www.cellprofiler.org
+Version:5
+DateRevision:424
+GitHash:
+ModuleCount:13
+HasImagePlaneDetails:False
+
+Images:[module_num:1|svn_version:'Unknown'|variable_revision_number:2|show_window:False|notes:['Images module is left blank as we are giving the path to the corrected images in the CLI']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    :
+    Filter images?:Images only
+    Select the rule criteria:and (extension does isimage) (directory doesnot containregexp "[\\\\/]\\.")
+
+Metadata:[module_num:2|svn_version:'Unknown'|variable_revision_number:6|show_window:False|notes:['Extract metadata from file names and folder names using regular expressions.', '', 'The only metadata that will be outputed in the SQLite DB file are:', '', 'Plate', 'Well', 'Site', '', 'The rest of the information is useful to make sure that the expression is working, but can be removed/not necessary.']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Extract metadata?:Yes
+    Metadata data type:Text
+    Metadata types:{"Channel": "integer", "FileLocation": "text", "Frame": "text", "Plate": "text", "Series": "text", "Site": "integer", "Stain": "float", "Well": "text"}
+    Extraction method count:2
+    Metadata extraction method:Extract from file/folder names
+    Metadata source:File name
+    Regular expression to extract from file name:(?P<Well>[A-Z]{1}[0-9]{1,2})_01_(?P<Channel>[1-3]{1})_(?P<Site>[1-4]{1})_(?P<Stain>DAPI|GFP|RFP)
+    Regular expression to extract from folder name:(?P<Date>[0-9]{4}_[0-9]{2}_[0-9]{2})$
+    Extract metadata from:All images
+    Select the filtering criteria:and (file does contain "")
+    Metadata file location:Elsewhere...|
+    Match file and image metadata:[]
+    Use case insensitive matching?:No
+    Metadata file name:None
+    Does cached metadata exist?:No
+    Metadata extraction method:Extract from file/folder names
+    Metadata source:Folder name
+    Regular expression to extract from file name:^(?P<Plate>.*)_(?P<Well>[A-P][0-9]{2})_s(?P<Site>[0-9])_w(?P<ChannelNumber>[0-9])
+    Regular expression to extract from folder name:Corrected_(?P<Plate>Plate_[0-9]{1})
+    Extract metadata from:All images
+    Select the filtering criteria:and (file does contain "")
+    Metadata file location:Elsewhere...|
+    Match file and image metadata:[]
+    Use case insensitive matching?:No
+    Metadata file name:None
+    Does cached metadata exist?:No
+
+NamesAndTypes:[module_num:3|svn_version:'Unknown'|variable_revision_number:8|show_window:False|notes:['Assign files to their respective channel (only 3):', '', 'DAPI', 'GFP', 'RFP']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Assign a name to:Images matching rules
+    Select the image type:Grayscale image
+    Name to assign these images:DNA
+    Match metadata:[]
+    Image set matching method:Order
+    Set intensity range from:Image metadata
+    Assignments count:3
+    Single images count:0
+    Maximum intensity:255.0
+    Process as 3D?:No
+    Relative pixel spacing in X:1.0
+    Relative pixel spacing in Y:1.0
+    Relative pixel spacing in Z:1.0
+    Select the rule criteria:and (file does contain "DAPI")
+    Name to assign these images:DAPI
+    Name to assign these objects:Cell
+    Select the image type:Grayscale image
+    Set intensity range from:Image metadata
+    Maximum intensity:255.0
+    Select the rule criteria:and (file does contain "GFP")
+    Name to assign these images:GFP
+    Name to assign these objects:Nucleus
+    Select the image type:Grayscale image
+    Set intensity range from:Image metadata
+    Maximum intensity:255.0
+    Select the rule criteria:and (file does contain "RFP")
+    Name to assign these images:RFP
+    Name to assign these objects:Cytoplasm
+    Select the image type:Grayscale image
+    Set intensity range from:Image metadata
+    Maximum intensity:255.0
+
+Groups:[module_num:4|svn_version:'Unknown'|variable_revision_number:2|show_window:False|notes:['We do not use the Groups module.']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Do you want to group your images?:No
+    grouping metadata count:1
+    Metadata category:None
+
+IdentifyPrimaryObjects:[module_num:5|svn_version:'Unknown'|variable_revision_number:15|show_window:False|notes:['These are the current best parameters to segment nuclei from the DAPI channel']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Select the input image:DAPI
+    Name the primary objects to be identified:Nuclei
+    Typical diameter of objects, in pixel units (Min,Max):30,90
+    Discard objects outside the diameter range?:Yes
+    Discard objects touching the border of the image?:Yes
+    Method to distinguish clumped objects:None
+    Method to draw dividing lines between clumped objects:Shape
+    Size of smoothing filter:10
+    Suppress local maxima that are closer than this minimum allowed distance:7.0
+    Speed up by using lower-resolution image to find local maxima?:Yes
+    Fill holes in identified objects?:After both thresholding and declumping
+    Automatically calculate size of smoothing filter for declumping?:Yes
+    Automatically calculate minimum allowed distance between local maxima?:Yes
+    Handling of objects if excessive number of objects identified:Continue
+    Maximum number of objects:500
+    Use advanced settings?:Yes
+    Threshold setting version:12
+    Threshold strategy:Global
+    Thresholding method:Otsu
+    Threshold smoothing scale:1.3488
+    Threshold correction factor:1.0
+    Lower and upper bounds on threshold:0.0,1.0
+    Manual threshold:0.0
+    Select the measurement to threshold with:None
+    Two-class or three-class thresholding?:Three classes
+    Log transform before thresholding?:No
+    Assign pixels in the middle intensity class to the foreground or the background?:Foreground
+    Size of adaptive window:50
+    Lower outlier fraction:0.05
+    Upper outlier fraction:0.05
+    Averaging method:Mean
+    Variance method:Standard deviation
+    # of deviations:2.0
+    Thresholding method:Minimum Cross-Entropy
+
+IdentifySecondaryObjects:[module_num:6|svn_version:'Unknown'|variable_revision_number:10|show_window:False|notes:['These are the current best parameters to segment whole cells using the RFP (actin) channel']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Select the input objects:Nuclei
+    Name the objects to be identified:Cells
+    Select the method to identify the secondary objects:Propagation
+    Select the input image:RFP
+    Number of pixels by which to expand the primary objects:10
+    Regularization factor:0.05
+    Discard secondary objects touching the border of the image?:Yes
+    Discard the associated primary objects?:No
+    Name the new primary objects:Nuclei
+    Fill holes in identified objects?:Yes
+    Threshold setting version:12
+    Threshold strategy:Global
+    Thresholding method:Otsu
+    Threshold smoothing scale:1.3488
+    Threshold correction factor:1.0
+    Lower and upper bounds on threshold:0.0,1.0
+    Manual threshold:0.0
+    Select the measurement to threshold with:None
+    Two-class or three-class thresholding?:Three classes
+    Log transform before thresholding?:No
+    Assign pixels in the middle intensity class to the foreground or the background?:Foreground
+    Size of adaptive window:50
+    Lower outlier fraction:0.05
+    Upper outlier fraction:0.05
+    Averaging method:Mean
+    Variance method:Standard deviation
+    # of deviations:2.0
+    Thresholding method:Otsu
+
+IdentifyTertiaryObjects:[module_num:7|svn_version:'Unknown'|variable_revision_number:3|show_window:False|notes:['This module creates a third object from the first two where the nuclei is subtracted from the cells to create cytoplasm']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Select the larger identified objects:Cells
+    Select the smaller identified objects:Nuclei
+    Name the tertiary objects to be identified:Cytoplasm
+    Shrink smaller object prior to subtraction?:Yes
+
+ConvertObjectsToImage:[module_num:8|svn_version:'Unknown'|variable_revision_number:1|show_window:False|notes:[]|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Select the input objects:Nuclei
+    Name the output image:MaskNuclei
+    Select the color format:Binary (black & white)
+    Select the colormap:Default
+
+ConvertObjectsToImage:[module_num:9|svn_version:'Unknown'|variable_revision_number:1|show_window:False|notes:[]|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Select the input objects:Cells
+    Name the output image:MaskCells
+    Select the color format:Binary (black & white)
+    Select the colormap:Default
+
+ConvertObjectsToImage:[module_num:10|svn_version:'Unknown'|variable_revision_number:1|show_window:False|notes:[]|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Select the input objects:Cytoplasm
+    Name the output image:MaskCytoplasm
+    Select the color format:Binary (black & white)
+    Select the colormap:Default
+
+SaveImages:[module_num:11|svn_version:'Unknown'|variable_revision_number:16|show_window:False|notes:[]|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Select the type of image to save:Image
+    Select the image to save:MaskNuclei
+    Select method for constructing file names:From image filename
+    Select image name for file prefix:DAPI
+    Enter single file name:OrigBlue
+    Number of digits:4
+    Append a suffix to the image file name?:Yes
+    Text to append to the image name:_MaskNuclei
+    Saved file format:tiff
+    Output file location:Default Output Folder|
+    Image bit depth:8-bit integer
+    Overwrite existing files without warning?:No
+    When to save:Every cycle
+    Record the file and path information to the saved image?:No
+    Create subfolders in the output folder?:No
+    Base image folder:Elsewhere...|
+    How to save the series:T (Time)
+    Save with lossless compression?:Yes
+
+SaveImages:[module_num:12|svn_version:'Unknown'|variable_revision_number:16|show_window:False|notes:[]|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Select the type of image to save:Image
+    Select the image to save:MaskCells
+    Select method for constructing file names:From image filename
+    Select image name for file prefix:RFP
+    Enter single file name:OrigBlue
+    Number of digits:4
+    Append a suffix to the image file name?:Yes
+    Text to append to the image name:_MaskCells
+    Saved file format:tiff
+    Output file location:Default Output Folder|
+    Image bit depth:8-bit integer
+    Overwrite existing files without warning?:No
+    When to save:Every cycle
+    Record the file and path information to the saved image?:No
+    Create subfolders in the output folder?:No
+    Base image folder:Elsewhere...|
+    How to save the series:T (Time)
+    Save with lossless compression?:Yes
+
+SaveImages:[module_num:13|svn_version:'Unknown'|variable_revision_number:16|show_window:False|notes:[]|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Select the type of image to save:Image
+    Select the image to save:MaskCytoplasm
+    Select method for constructing file names:From image filename
+    Select image name for file prefix:RFP
+    Enter single file name:OrigBlue
+    Number of digits:4
+    Append a suffix to the image file name?:Yes
+    Text to append to the image name:_MaskCytoplasm
+    Saved file format:tiff
+    Output file location:Default Output Folder|
+    Image bit depth:8-bit integer
+    Overwrite existing files without warning?:No
+    When to save:Every cycle
+    Record the file and path information to the saved image?:No
+    Create subfolders in the output folder?:No
+    Base image folder:Elsewhere...|
+    How to save the series:T (Time)
+    Save with lossless compression?:Yes


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR adds the ability for `CytoDataFrame`'s to display segmentation mask outline capabilities for image displays within notebooks. This is an optional feature which can be used in conjunction with the existing image display capabilities (if no masks are found only the image crop is displayed). I've updated the example notebook to include a demonstration of what this looks like. 

Thanks for any feedback or thoughts you may have as part of this!

Closes #33 

## What kind of change(s) are included?

- [x] Feature (adds or updates new capabilities)
- [ ] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] I have searched for existing content to ensure this is not a duplicate.
- [x] I have performed a self-review of these additions (including spelling, grammar, and related).
- [x] These changes pass all pre-commit checks.
- [x] I have added comments to my code to help provide understanding
- [x] I have added a test which covers the code changes found within this PR
- [x] I have deleted all non-relevant text in this pull request template.
