### PR TITLE
Reduce UMAP rendered notebook size and avoid docsite `.doctree` files for publishing

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -32,6 +32,8 @@ jobs:
           touch pages/.nojekyll
           cd docs
           poetry run sphinx-multiversion src build
+          # remove any doctrees dirs which aren't needed for publishing
+          find docs/build -type d -name '.doctrees' -exec rm -rf {} +
           cp -r build/* ../pages/
       - name: Add index redirector to latest docs
         run: |

--- a/docs/src/examples/jump_umap_analysis_with_cosmicqc.py
+++ b/docs/src/examples/jump_umap_analysis_with_cosmicqc.py
@@ -318,7 +318,7 @@ print(
 )
 
 # show histograms to help visualize the data
-df_labeled_outliers.show_report();
+df_labeled_outliers.show_report();  # fmt: skip
 
 # ## Prepare data for analysis with pycytominer
 

--- a/docs/src/examples/jump_umap_analysis_with_cosmicqc.py
+++ b/docs/src/examples/jump_umap_analysis_with_cosmicqc.py
@@ -318,7 +318,8 @@ print(
 )
 
 # show histograms to help visualize the data
-df_labeled_outliers.show_report()
+df_labeled_outliers.show_report();
+
 # ## Prepare data for analysis with pycytominer
 
 # +
@@ -490,6 +491,8 @@ plot_hvplot_scatter(
     cmap=px.colors.sequential.Greens[4:],
     clabel="density of single cells",
 )
+# conserve filespace by displaying export instead of dynamic plot
+Image(image_with_all_outliers)
 
 # show a UMAP for all outliers within the data
 plot_hvplot_scatter(
@@ -647,6 +650,8 @@ plot_hvplot_scatter(
     cmap=px.colors.sequential.Greens[4:],
     clabel="density of single cells",
 )
+# conserve filespace by displaying export instead of dynamic plot
+Image(image_without_all_outliers)
 
 # compare the UMAP images with and without outliers side by side
 HTML(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,8 @@ select = [
 # ignore typing rules for tests
 "tests/*" = ["ANN201", "PLR0913"]
 # ignore long line and func def warnings with notebooks
-"docs/src/examples/*.ipynb" = ["E501", "PLR0913"]
-"docs/src/examples/*.py" = ["E501", "PLR0913"]
+"docs/src/examples/*.ipynb" = ["E501", "PLR0913", "E703"]
+"docs/src/examples/*.py" = ["E501", "PLR0913", "E703"]
 
 [tool.jupytext]
 formats = "ipynb,py:light"


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR addresses #93 by removing `.doctree` files before pushing to GitHub Pages. While I investigated this I also reduced the file size of the JUMP UMAP notebook by updating two UMAP output cells to show images rather than dynamic plots.

Closes #93

## What kind of change(s) are included?

- [x] Documentation (changes docs or other related content)
- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] I have searched for existing content to ensure this is not a duplicate.
- [x] I have performed a self-review of these additions (including spelling, grammar, and related).
- [x] These changes pass all pre-commit checks.
- [x] I have added comments to my code to help provide understanding
- [ ] I have added a test which covers the code changes found within this PR
- [x] I have deleted all non-relevant text in this pull request template.
