### PR TITLE
Turn off automatic notebook execution for docs builds

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -88,7 +88,10 @@ html_theme_options = {
 }
 
 # Options for myst-nb
-nb_execution_mode = "auto"
+# turn off notebook execution for docs builds
+# (we rely on the notebook already being processed
+# prior to the publish to help navigate compute needs)
+nb_execution_mode = "off"
 
 # set option to avoid rendering default variables
 autodoc_preserve_defaults = True


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR turns off automatic notebook execution for notebooks on builds for docs. Currently this causes an error when attempting to re-run certain cells within the notebooks (showing errors within the docsite). After this change I expect the notebooks to render as-is, with the expectation that they are processed before being added to the examples.

Closes #96 

## What kind of change(s) are included?

- [ ] Documentation (changes docs or other related content)
- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] I have searched for existing content to ensure this is not a duplicate.
- [x] I have performed a self-review of these additions (including spelling, grammar, and related).
- [x] These changes pass all pre-commit checks.
- [x] I have added comments to my code to help provide understanding
- [ ] I have added a test which covers the code changes found within this PR
- [x] I have deleted all non-relevant text in this pull request template.
