### PR TITLE
Bump macos gh actions runner version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-14]
     runs-on: ${{ matrix.os }}
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
This PR bumps the version of MacOS used by GH Actions runners as `macos-13` is no longer `macos-latest` (instead, latest is now `macos-14`). This also provides us the capability of testing with ARM-based architectures which could be important to understand when it comes to functionality.