### PR TITLE
Update GH Actions ubuntu version

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     # only build and deploy docs if the actor is not dependabot
     if: ${{ github.actor != 'dependabot[bot]' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pre_commit_checks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       # checks out the repo
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-24.04, macos-14]
     runs-on: ${{ matrix.os }}
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
This PR updates ubuntu-latest to 24.04 (latest) for use within GH Actions.